### PR TITLE
feat: add sort_by and sort_order to case search

### DIFF
--- a/internal/domain/paging.go
+++ b/internal/domain/paging.go
@@ -1,8 +1,10 @@
 package domain
 
 type PagingFilter struct {
-	Limit  int
-	Offset int
+	Limit     int
+	Offset    int
+	SortBy    string
+	SortOrder string
 }
 
 type Paging struct {

--- a/internal/infra/entrypoint/rest/case_controller.go
+++ b/internal/infra/entrypoint/rest/case_controller.go
@@ -141,8 +141,10 @@ func (c *CaseController) CreateBatch(ctx *gin.Context) {
 func (c *CaseController) parseQueryToFilters(ctx *gin.Context) domain.CaseFilters {
 	filters := domain.CaseFilters{
 		PagingFilter: domain.PagingFilter{
-			Limit:  10,
-			Offset: 0,
+			Limit:     10,
+			Offset:    0,
+			SortBy:    "created_at",
+			SortOrder: "DESC",
 		},
 	}
 
@@ -202,6 +204,14 @@ func (c *CaseController) parseQueryToFilters(ctx *gin.Context) domain.CaseFilter
 		if err == nil {
 			filters.Offset = parsedOffset
 		}
+	}
+
+	if sortBy := ctx.Query("sort_by"); sortBy != "" {
+		filters.SortBy = sortBy
+	}
+
+	if sortOrder := strings.ToUpper(ctx.Query("sort_order")); sortOrder == "ASC" || sortOrder == "DESC" {
+		filters.SortOrder = sortOrder
 	}
 
 	return filters

--- a/internal/infra/entrypoint/rest/case_controller_test.go
+++ b/internal/infra/entrypoint/rest/case_controller_test.go
@@ -27,7 +27,7 @@ func TestCaseController_parseQueryToFilters(t *testing.T) {
 			query: url.Values{"case_id": {"abc-123"}},
 			expected: domain.CaseFilters{
 				CaseID:       []string{"abc-123"},
-				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0},
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "created_at", SortOrder: "DESC"},
 			},
 		},
 		{
@@ -35,7 +35,7 @@ func TestCaseController_parseQueryToFilters(t *testing.T) {
 			query: url.Values{"case_id": {"abc-123,def-456,ghi-789"}},
 			expected: domain.CaseFilters{
 				CaseID:       []string{"abc-123", "def-456", "ghi-789"},
-				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0},
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "created_at", SortOrder: "DESC"},
 			},
 		},
 		{
@@ -45,7 +45,7 @@ func TestCaseController_parseQueryToFilters(t *testing.T) {
 				CaseID:       []string{"abc-123", "def-456"},
 				Status:       []string{"New"},
 				Region:       []string{"1"},
-				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0},
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "created_at", SortOrder: "DESC"},
 			},
 		},
 		{
@@ -53,14 +53,14 @@ func TestCaseController_parseQueryToFilters(t *testing.T) {
 			query: url.Values{"status": {"New"}},
 			expected: domain.CaseFilters{
 				Status:       []string{"New"},
-				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0},
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "created_at", SortOrder: "DESC"},
 			},
 		},
 		{
 			name:  "empty query returns defaults",
 			query: url.Values{},
 			expected: domain.CaseFilters{
-				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0},
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "created_at", SortOrder: "DESC"},
 			},
 		},
 		{
@@ -68,7 +68,28 @@ func TestCaseController_parseQueryToFilters(t *testing.T) {
 			query: url.Values{"case_id": {"abc-123"}, "limit": {"20"}, "offset": {"5"}},
 			expected: domain.CaseFilters{
 				CaseID:       []string{"abc-123"},
-				PagingFilter: domain.PagingFilter{Limit: 20, Offset: 5},
+				PagingFilter: domain.PagingFilter{Limit: 20, Offset: 5, SortBy: "created_at", SortOrder: "DESC"},
+			},
+		},
+		{
+			name:  "sort_by updated_at",
+			query: url.Values{"sort_by": {"updated_at"}},
+			expected: domain.CaseFilters{
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "updated_at", SortOrder: "DESC"},
+			},
+		},
+		{
+			name:  "sort_by updated_at with sort_order ASC",
+			query: url.Values{"sort_by": {"updated_at"}, "sort_order": {"asc"}},
+			expected: domain.CaseFilters{
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "updated_at", SortOrder: "ASC"},
+			},
+		},
+		{
+			name:  "invalid sort_by falls back to default",
+			query: url.Values{"sort_by": {"drop table cases"}},
+			expected: domain.CaseFilters{
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "drop table cases", SortOrder: "DESC"},
 			},
 		},
 	}
@@ -102,7 +123,7 @@ func TestCaseController_SearchCases(t *testing.T) {
 			query: url.Values{"case_id": {"id-1,id-2"}},
 			expectedFilters: domain.CaseFilters{
 				CaseID:       []string{"id-1", "id-2"},
-				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0},
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "created_at", SortOrder: "DESC"},
 			},
 			serviceResult:  domain.PagingResult[domain.Case]{Result: []domain.Case{}, Paging: domain.Paging{Total: 0, Limit: 10, Offset: 0}},
 			expectedStatus: http.StatusOK,
@@ -112,7 +133,7 @@ func TestCaseController_SearchCases(t *testing.T) {
 			query: url.Values{"case_id": {"id-1"}},
 			expectedFilters: domain.CaseFilters{
 				CaseID:       []string{"id-1"},
-				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0},
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "created_at", SortOrder: "DESC"},
 			},
 			serviceResult:  domain.PagingResult[domain.Case]{Result: []domain.Case{}, Paging: domain.Paging{Total: 0, Limit: 10, Offset: 0}},
 			expectedStatus: http.StatusOK,
@@ -121,7 +142,7 @@ func TestCaseController_SearchCases(t *testing.T) {
 			name:  "no case_id filter passes empty slice",
 			query: url.Values{},
 			expectedFilters: domain.CaseFilters{
-				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0},
+				PagingFilter: domain.PagingFilter{Limit: 10, Offset: 0, SortBy: "created_at", SortOrder: "DESC"},
 			},
 			serviceResult:  domain.PagingResult[domain.Case]{Result: []domain.Case{}, Paging: domain.Paging{Total: 0, Limit: 10, Offset: 0}},
 			expectedStatus: http.StatusOK,

--- a/internal/infra/repository/database/case_repository.go
+++ b/internal/infra/repository/database/case_repository.go
@@ -76,7 +76,8 @@ func (r *caseRepository) Search(ctx context.Context, filters domain.CaseFilters)
 	limitArgs = append(limitArgs, whereArgs...)
 	limitArgs = append(limitArgs, filters.Limit, filters.Offset)
 
-	query := fmt.Sprintf("SELECT * FROM cases WHERE %s ORDER BY created_at DESC %s", strings.Join(whereQuery, " AND "), limitQuery)
+	orderBy := buildOrderBy(filters.SortBy, filters.SortOrder, validCaseSortColumns)
+	query := fmt.Sprintf("SELECT * FROM cases WHERE %s ORDER BY %s %s", strings.Join(whereQuery, " AND "), orderBy, limitQuery)
 	countQuery := fmt.Sprintf("SELECT COUNT(*) FROM cases WHERE %s", strings.Join(whereQuery, " AND "))
 
 	var foundCases []CaseDTO
@@ -306,8 +307,8 @@ func (r *caseRepository) SearchFull(ctx context.Context, filters domain.CaseFilt
 		LEFT JOIN customers AS cu ON ca.customer_id = cu.customer_id
 		LEFT JOIN products AS pr ON ca.product_id = pr.product_id
 		WHERE %s
-		ORDER BY ca.created_at DESC
-		%s`, strings.Join(whereQuery, " AND "), limitQuery)
+		ORDER BY ca.%s
+		%s`, strings.Join(whereQuery, " AND "), buildOrderBy(filters.SortBy, filters.SortOrder, validCaseSortColumns), limitQuery)
 
 	countQuery := fmt.Sprintf(`SELECT
 		COUNT(*)

--- a/internal/infra/repository/database/utils.go
+++ b/internal/infra/repository/database/utils.go
@@ -100,6 +100,29 @@ func buildLikePart[S comparable](filters []S, startIdx int, key string) string {
 	return part
 }
 
+var validCaseSortColumns = map[string]bool{
+	"created_at":  true,
+	"updated_at":  true,
+	"due_date":    true,
+	"target_date": true,
+	"status":      true,
+	"priority":    true,
+}
+
+func buildOrderBy(sortBy, sortOrder string, allowedColumns map[string]bool) string {
+	col := "created_at"
+	if allowedColumns[sortBy] {
+		col = sortBy
+	}
+
+	ord := "DESC"
+	if sortOrder == "ASC" {
+		ord = "ASC"
+	}
+
+	return fmt.Sprintf("%s %s", col, ord)
+}
+
 func createChunks[T any](slice []T, size int) [][]T {
 	var chunks [][]T
 	for i := 0; i < len(slice); i += size {


### PR DESCRIPTION
Adds sort_by and sort_order query params to case search endpoints (Search and SearchFull). Defaults to created_at DESC. Column names are validated against an allowlist in the repository to prevent SQL injection.

Supported columns: created_at, updated_at, due_date, target_date, status, priority.

## 📝 Descrição
[Explique de forma clara e resumida o propósito deste PR. Qual problema ele resolve ou qual funcionalidade ele adiciona? Se houver um ticket/issue associado, coloque o link aqui.]

## 🔄 Mudanças Feitas
- [Explique tecnicamente o que foi alterado]
- [Ex: Adiciona a rota `/api/v1/resource`]
- [Ex: Refatora o serviço `X` para melhorar a performance]

## 📋 Checklist de Validação
*Por favor, marque os itens abaixo antes de solicitar a revisão:*

- [ ] Meu código segue os padrões do projeto e passou no linter (`golangci-lint`).
- [ ] Adicionei ou atualizei os testes unitários para cobrir essas mudanças.
- [ ] Todos os testes locais e no pipeline de CI estão passando.
- [ ] Atualizei a documentação necessária (ex: Swagger/OpenAPI, README).
- [ ] Verifiquei se não há dados sensíveis (senhas, tokens, chaves) "hardcoded" no código.
- [ ] O título do PR é descritivo e reflete o conteúdo da mudança.
