### PR TITLE
fix: make auto-backport PRs pass branch/title validation

### DIFF
--- a/.github/workflows/auto-backport.yml
+++ b/.github/workflows/auto-backport.yml
@@ -48,7 +48,7 @@ jobs:
           for TARGET in "${TARGETS[@]}"; do
             echo "Iniciando backport para $TARGET..."
 
-            BP_BRANCH="backport-pr-${PR_NUMBER}-to-${TARGET//\//-}"
+            BP_BRANCH="chore/backport-pr-${PR_NUMBER}-to-${TARGET//\//-}"
 
             git checkout "$TARGET"
             git pull origin "$TARGET"
@@ -66,17 +66,17 @@ jobs:
             git push origin "$BP_BRANCH"
 
             PR_BODY="Este é um PR gerado automaticamente trazendo as alterações do PR #${PR_NUMBER} (main) para a branch \`${TARGET}\`."
-            PR_TITLE_PREFIX="🔄 Backport PR #${PR_NUMBER} para ${TARGET}"
+            PR_TITLE="chore: backport PR #${PR_NUMBER} to ${TARGET}"
             if [ "$CONFLICT" = true ]; then
-              PR_TITLE_PREFIX="⚠️ $PR_TITLE_PREFIX (conflitos)"
-              PR_BODY="$PR_BODY Merge automático encontrou conflitos — resolva os marcadores antes de aprovar."
+              PR_TITLE="$PR_TITLE (conflicts)"
+              PR_BODY="$PR_BODY ⚠️ Merge automático encontrou conflitos — resolva os marcadores antes de aprovar."
             fi
 
             # Criar o Pull Request com a atribuição automática
             gh pr create \
               --base "$TARGET" \
               --head "$BP_BRANCH" \
-              --title "$PR_TITLE_PREFIX" \
+              --title "$PR_TITLE" \
               --body "$PR_BODY" \
               --assignee "$MERGED_BY"
           done


### PR DESCRIPTION
## Summary
- PR #82 provou que o merge/push do backport agora funciona, mas ficou preso: branch `backport-pr-80-to-develop` e título `🔄 Backport PR #80 para develop` não passam nos checks obrigatórios (`validate-branch` exige prefixo `feature/|fix/|docs/|chore/|dependabot/`; `Validar Conventional Commits` exige tipo Conventional Commits no título).
- Passa a usar `chore/backport-pr-N-to-TARGET` como nome de branch e `chore: backport PR #N to TARGET` como título.

## Test plan
- [x] YAML validado
- [ ] Validar em um merge real pra `main` que o PR de backport passa nos checks obrigatórios

🤖 Generated with [Claude Code](https://claude.com/claude-code)